### PR TITLE
Fix/register issue

### DIFF
--- a/backend/src/main/java/com/food/backend/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/food/backend/controller/AuthenticationController.java
@@ -8,6 +8,8 @@ import com.food.backend.responses.LoginResponse;
 import com.food.backend.service.AuthenticationService;
 import com.food.backend.service.EmailService;
 import com.food.backend.service.JwtService;
+import com.food.backend.utils.classes.ApiResponse;
+import com.food.backend.utils.classes.ResponseUtil;
 import jakarta.mail.MessagingException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -36,9 +38,14 @@ public class AuthenticationController {
         this.emailService = emailService;
     }
     @PostMapping("/signup")
-    public ResponseEntity<User> register(@RequestBody RegisterUserDto registerUserDto) {
-        User user = authenticationService.signup(registerUserDto);
-        return ResponseEntity.ok(user);
+    public ResponseEntity<ApiResponse<User>> register(@RequestBody RegisterUserDto registerUserDto) {
+        try {
+            return authenticationService.registerUser(registerUserDto)
+                    .map(user -> ResponseUtil.successResponse(user, "User registered"))
+                    .orElseGet(() -> ResponseUtil.badRequestResponse("Registration failed"));
+        } catch (IllegalArgumentException e) {
+            return ResponseUtil.badRequestResponse(e.getMessage());
+        }
     }
 
     @PostMapping("/login")

--- a/backend/src/main/java/com/food/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/com/food/backend/service/AuthenticationService.java
@@ -28,13 +28,27 @@ public class AuthenticationService {
     }
 
     @Transactional
-    public User signup(RegisterUserDto registerUserDto) {
+    public Optional<User> registerUser(RegisterUserDto registerUserDto) {
+        validateUserDoesNotExist(registerUserDto.getUsername());
+
+        User user = createUser(registerUserDto);
+        User savedUser = userRepository.save(user);
+
+        return Optional.of(savedUser);
+    }
+    private void validateUserDoesNotExist(String username) {
+        if (findByUsername(username.toLowerCase()).isPresent()) {
+            throw new IllegalArgumentException("User already exists");
+        }
+    }
+
+    private User createUser(RegisterUserDto registerUserDto) {
         User user = new User();
-        user.setUsername(registerUserDto.getUsername());
+        user.setUsername(registerUserDto.getUsername().toLowerCase());
         user.setPassword(passwordEncoder.encode(registerUserDto.getPassword()));
         user.setRoles(Set.of(Role.ROLE_EMPLOYEE));
         user.setEnabled(true);
-        return userRepository.save(user);
+        return user;
     }
     @Transactional
     public Optional<User> changeRoles(String username, Set<Role> roles) {


### PR DESCRIPTION
# Pull Request: Fix/Register Username Uniqueness Issue

## Overview
This pull request addresses the issue of allowing multiple accounts to be registered with the same username. The registration process has been updated to enforce unique usernames, returning a `BadRequest` response when a duplicate username is detected.

## Changes Made
- **Username Uniqueness Validation:**
  - Implemented a check during the registration process to ensure that the username is unique across all accounts.
  - If a duplicate username is attempted, the system now returns a `400 Bad Request` response with an appropriate error message.

## Error Handling
- Added error handling logic to provide clear feedback to users attempting to register with an already taken username.
- The error response includes a descriptive message indicating that the username is already in use.

## Testing
- Conducted thorough testing of the registration process to verify that:
  - Users cannot register with a username that already exists.
  - The correct error message is returned when a duplicate username is provided.
  
## Additional Notes
- Please review the changes made to the registration logic, particularly the new validation checks for username uniqueness.
---

Feel free to reach out if you need any further modifications or additional information!
