### PR TITLE
feat/roles-in-login-response

### DIFF
--- a/backend/src/main/java/com/food/backend/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/food/backend/controller/AuthenticationController.java
@@ -49,20 +49,16 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> authenticate(@RequestBody LoginUserDto loginUserDto) {
+    public ResponseEntity<ApiResponse<Object>> authenticate(@RequestBody LoginUserDto loginUserDto) {
         try{
             User authenticatedUser = authenticationService.authenticate(loginUserDto);
             String token = jwtService.generateToken(authenticatedUser);
-            LoginResponse loginResponse = new LoginResponse(token, jwtService.getJwtExpirationTime());
-            return ResponseEntity.ok(loginResponse);
-
+            LoginResponse loginResponse = new LoginResponse(token, jwtService.getJwtExpirationTime(), authenticatedUser.getRoles());
+            return ResponseUtil.successResponse(loginResponse, "Login successful");
         }
         catch (UsernameNotFoundException e) {
-            return ResponseEntity.badRequest().
-                    body(new LoginResponse("Invalid username or password", 0));
+            return ResponseUtil.badRequestResponse("Invalid username or password");
         }
-
-
     }
 
     // temporary for email testing

--- a/backend/src/main/java/com/food/backend/responses/LoginResponse.java
+++ b/backend/src/main/java/com/food/backend/responses/LoginResponse.java
@@ -1,16 +1,23 @@
 package com.food.backend.responses;
 
+import com.food.backend.model.Role;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Set;
 
 @Getter
 @Setter
 public class LoginResponse {
     private String token;
     private long expiresIn;
+    private Set<Role> roles;
 
-    public LoginResponse(String token, long expiresIn) {
+    public LoginResponse(String token, long expiresIn, Set<Role> roles) {
         this.token = token;
         this.expiresIn = expiresIn;
+        this.roles = roles;
+
     }
 }
+


### PR DESCRIPTION
# Pull Request: Feat/Roles in Login Response

## Overview
This pull request enhances the login functionality by including user roles in the response payload when a user successfully logs in. This improvement allows the frontend to have immediate access to the user's roles, facilitating role-based access control.

## Changes Made
- **Roles Included in Login Response:**
    - Updated the login response structure to include an array of roles associated with the authenticated user.
    - Ensured that roles are fetched from the user’s profile and returned alongside other login details.

## Example Response
Upon a successful login, the response now includes:
```json
{
    "data": {
        "token": "example_token",
        "expiresIn": 3600000,
        "roles": [
            "ROLE_EXAMPLE"
        ]
    },
    "message": "Login successful",
    "status": 200
}
