### PR TITLE
Fix/roles-issues

### DIFF
--- a/gui/Test/src/main/java/sample/test/RegisterViewController.java
+++ b/gui/Test/src/main/java/sample/test/RegisterViewController.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
@@ -79,8 +80,12 @@ public class RegisterViewController implements Initializable {
             String jwtToken = JwtTokenService.getInstance().getJwtToken();
 
             if (jwtToken != null && !jwtToken.isBlank()) {
-                HttpResponse<String> response = sendRegistrationRequest(registerUserDto, jwtToken);
-                handleRegistrationResponse(response);
+                if (isUserManager()) {
+                    HttpResponse<String> response = sendRegistrationRequest(registerUserDto, jwtToken);
+                    handleRegistrationResponse(response);
+                } else {
+                    registrationMessageLabel.setText("Only managers can register a new user.");
+                }
             } else {
                 registrationMessageLabel.setText("You must be logged in to register a new user.");
             }
@@ -88,6 +93,11 @@ public class RegisterViewController implements Initializable {
             e.printStackTrace();
             registrationMessageLabel.setText("Error occurred during registration.");
         }
+    }
+
+    private boolean isUserManager() {
+        List<String> userRoles = JwtTokenService.getInstance().getUserRoles();
+        return userRoles != null && userRoles.contains("ROLE_MANAGER");
     }
 
     private RegisterUserDto collectUserInput() {

--- a/gui/Test/src/main/java/sample/test/service/JwtTokenService.java
+++ b/gui/Test/src/main/java/sample/test/service/JwtTokenService.java
@@ -1,8 +1,11 @@
 package sample.test.service;
 
+import java.util.List;
+
 public class JwtTokenService {
     private static JwtTokenService instance;
     private String jwtToken;
+    private List<String> userRoles;
 
     private JwtTokenService() {
     }
@@ -21,4 +24,13 @@ public class JwtTokenService {
     public String getJwtToken() {
         return jwtToken;
     }
+
+    public void setUserRoles(List<String> roles) {
+        this.userRoles = roles;
+    }
+
+    public List<String> getUserRoles() {
+        return userRoles;
+    }
+
 }


### PR DESCRIPTION
# Pull Request: Fix/Register Role-Based Access Control

## Overview
This pull request fixes the registration process by implementing role-based access control. The login process now extracts and stores the user roles in the JwtTokenService, and only users with the ROLE_MANAGER role are allowed to create new users via the registration form.

## Changes Made
**Role Extraction and Storage:**
- Updated the login process to extract user roles from the response payload and store them in the JwtTokenService alongside the JWT token.
- Implemented role management within JwtTokenService to keep track of the user’s roles throughout the session.

**Manager-Only Registration:**
- Added a check during registration to ensure that only users with the ROLE_MANAGER are permitted to register new users.
- If the logged-in user is not a manager, an error message is displayed: "Only managers can register a new user."

## Additional Notes
- The role-based access control for the registration feature is a crucial step toward ensuring that only authorized users can create new accounts.
- Please review the changes, particularly the logic in the login and registration processes, and let me know if further adjustments are needed.
