### PR TITLE
Feat/fetching menuItem by id

### DIFF
--- a/backend/src/main/java/com/food/backend/controller/MenuItemController.java
+++ b/backend/src/main/java/com/food/backend/controller/MenuItemController.java
@@ -4,6 +4,7 @@ import com.food.backend.dto.MenuItemDto;
 import com.food.backend.model.Enums.Category;
 import com.food.backend.model.MenuItem;
 import com.food.backend.service.MenuItemService;
+import com.food.backend.utils.classes.ResponseUtil;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,21 @@ public class MenuItemController {
     @GetMapping("/")
     public ResponseEntity<List<MenuItem>> getMenuItems() {
         return ResponseEntity.ok(menuItemService.findAll());
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getMenuItems(
+            @PathVariable("id") Long id
+    ) {
+        try{
+            MenuItem menuItem = menuItemService.findById(id).orElseThrow(() -> new EntityNotFoundException("Menu item with id " + id + " not found"));
+            return ResponseUtil.successResponse(menuItem, "Menu item retrieved successfully");
+        }
+        catch (EntityNotFoundException e){
+            return ResponseUtil.notFoundResponse(e.getMessage());
+        }
+        catch (Exception e){
+            return ResponseUtil.badRequestResponse("Error retrieving menu item: " + e.getMessage());
+        }
     }
 
     @GetMapping("/available")


### PR DESCRIPTION
## Feature: Fetch Menu Item by ID

### Description
This pull request introduces an endpoint to fetch a menu item by its ID.

### Changes
- Added a new endpoint:

### Error Handling
- **404 Not Found:** The server returns this status code when a menu item with the given ID is not found in the database.
- **400 Bad Request:** This status code is returned when the request is malformed or there is an issue processing it.

### Testing
- Fetching an existing menu item by ID.
- Handling a non-existing menu item (404).
- Handling invalid request cases (400).

## Endpoint Summary
| Method | Endpoint           | Description                       |
|--------|--------------------|-----------------------------------|
| GET    | `/menu/{id}`      | Retrieve menuItem details by ID       |
