### PR TITLE
Fix/Create Order didn't return Orders items

### DIFF
--- a/backend/src/main/java/com/food/backend/service/OrderService.java
+++ b/backend/src/main/java/com/food/backend/service/OrderService.java
@@ -53,7 +53,8 @@ public class OrderService {
         List<OrderItem> orderItemsList = createOrderItemsList(savedOrder, createOrderDto.getOrderItems());
         calculateAndSetTotalPrice(order, orderItemsList);
         saveOrder(order, orderItemsList);
-        return order;
+        savedOrder.setOrderItems(orderItemsList);
+        return savedOrder;
     }
 
     private void saveOrder(Order order, List<OrderItem> orderItemsList) {


### PR DESCRIPTION
## Pull Request: Fix/Create Order - Include Order Items in Returned Object

### Description
This pull request addresses an issue where the order creation endpoint did not return the associated order items in the response. The updated implementation now ensures that the returned Order object includes the `orderItems` field, providing a complete representation of the created order.

### Changes Made
- Modified the order creation logic to include `orderItems` in the returned Order object.

### Reason for Change
Previously, clients were unable to access the order items associated with a newly created order, leading to an incomplete response. By including `orderItems` in the response, we enhance the usability of the order creation endpoint and allow clients to receive all relevant data in a single request.

### Testing
- Manual testing has been performed to ensure the accuracy of the returned Order object.

### New Response Object
```json
{
    "data": {
        "orderId": 30,
        "preparedBy": null,
        "status": "IN_PREPARATION",
        "orderType": "DINE_IN",
        "totalPrice": 17.0,
        "orderTime": "2024-10-20T19:09:39.5742047",
        "boardCode": "0",
        "email": "email@gmail.com",
        "orderItems": [
            {
                "orderItemId": 33,
                "item": {
                    "name": "Kake Udon",
                    "description": " Simple udon served in a light soy-based broth, often garnished with green onions and tempura flakes",
                    "price": 17.0,
                    "available": true,
                    "category": "UDON_NOODLES",
                    "photoUrl": "https://hhyxgpzhygxxkfzmfcsi.supabase.co/storage/v1/object/public/images/kakoudon.jpg",
                    "id": 5
                },
                "quantity": 1,
                "totalPrice": 17.0
            }
        ]
    },
    "message": "Order created successfully",
    "status": 200
}