### PR TITLE
Fix/Correct number on liveorder board

### DIFF
--- a/backend/src/main/java/com/food/backend/service/LiveOrderBoard.java
+++ b/backend/src/main/java/com/food/backend/service/LiveOrderBoard.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 
 @Getter
@@ -30,13 +31,26 @@ public class LiveOrderBoard {
         this.liveOrderBoardCodes = new TreeSet<>();
         this.readyOrderBoardCodes = new HashSet<>();
         initializeOrderSets();
+
     }
 
     private void initializeOrderSets() {
         clearOrderSets();
         loadOrdersIntoSets();
         sendUpdatedOrderBoard();
+        getLastOrderNumber();
+    }
+    private void getLastOrderNumber() {
+        Number maxOrderNumber = getMaxOrderNumberFromLiveOrderBoardCodesList(liveOrderBoardCodes.stream());
+        Number maxReadyOrderNumber = getMaxOrderNumberFromLiveOrderBoardCodesList(readyOrderBoardCodes.stream());
+        LAST_NUMBER = Math.max(maxOrderNumber.intValue(), maxReadyOrderNumber.intValue());
+    }
 
+    private Number getMaxOrderNumberFromLiveOrderBoardCodesList(Stream<String> liveOrderBoardCodes) {
+        return liveOrderBoardCodes
+                .map(Integer::parseInt)
+                .max(Integer::compareTo)
+                .orElse(-1);
     }
 
     private void clearOrderSets() {


### PR DESCRIPTION
# Pull Request: Fix for Live Order Board Order Numbering

## Overview
This pull request addresses an issue with the order numbering on the Live Order Board. Previously, when a crash or unexpected error occurred, new orders would start numbering from zero. This behavior has been corrected to ensure that new orders resume numbering from the maximum of any previously existing orders.

## Changes Made
- Modified the order numbering so that new orders continue from the last maximum order number instead of starting from zero.

## Purpose
The primary goal of this fix is to improve the user experience by ensuring that order numbering is consistent and logical, even after unexpected interruptions. This change helps to maintain continuity in order tracking and reduces confusion for users.

## Testing
- Verified that new orders now start from the correct maximum order number after a crash.
- Conducted manual tests to ensure the Live Order Board reflects accurate order numbers across various scenarios.


## Additional Notes
Please reach out if there are any questions or further modifications needed.