### PR TITLE
Feat/sending notifs from GUI

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 .env
+/serviceAccountKey.json

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,7 +42,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'com.google.firebase:firebase-admin:9.1.1'
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
+
 
 }
 

--- a/backend/src/main/java/com/food/backend/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/food/backend/config/FirebaseConfig.java
@@ -1,0 +1,26 @@
+package com.food.backend.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+    @PostConstruct
+    public void initializeFirebase() {
+        try (InputStream serviceAccount = new FileInputStream("./serviceAccountKey.json")) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/backend/src/main/java/com/food/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/food/backend/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package com.food.backend.controller;
+
+import com.food.backend.dto.NotificationRequestDto;
+import com.food.backend.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications")
+@Tag(name = "Notifications", description = "Endpoints for sending notifications to a topic")
+@Validated
+public class NotificationController {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Operation(
+            summary = "Sends Notification to all clients within a topic",
+            description = "Every client subscribed to the topic will receive the notification"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Notification sent successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input data"),
+            @ApiResponse(responseCode = "403", description = "Forbidden, only managers can send notifications"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @PostMapping("/send/to/topic/{topic}")
+    @PreAuthorize("hasRole('MANAGER')")
+    @SecurityRequirement(name = "bearerAuth")
+    public String sendNotification(
+            @PathVariable @NotNull String topic,
+            @RequestBody @Valid NotificationRequestDto notificationRequestDto
+    ) {
+        return notificationService.sendNotificationToTopic(
+                topic,
+                notificationRequestDto.getTitle(),
+                notificationRequestDto.getBody(),
+                notificationRequestDto.getImage()
+        );
+    }
+}

--- a/backend/src/main/java/com/food/backend/dto/NotificationRequestDto.java
+++ b/backend/src/main/java/com/food/backend/dto/NotificationRequestDto.java
@@ -1,0 +1,25 @@
+package com.food.backend.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationRequestDto {
+
+    @NotEmpty(message = "Title is required")
+    private String title;
+
+    @NotEmpty(message = "Body is required")
+    private String body;
+
+    @Pattern(regexp = "^(https?)://[^\\s/$.?#].[^\\s]*$",
+            message = "Image must be a valid URL starting with http or https")
+    private String image;
+}

--- a/backend/src/main/java/com/food/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/food/backend/service/NotificationService.java
@@ -1,0 +1,29 @@
+package com.food.backend.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+
+    public String sendNotificationToTopic(String topic, String title, String body, String image) {
+        Message message = Message.builder()
+                .setTopic(topic)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .setImage(image)
+                        .build())
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            return "Notification sent: " + response;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Failed to send notification";
+        }
+    }
+}

--- a/gui/Test/src/main/java/sample/test/dto/NotificationRequestDto.java
+++ b/gui/Test/src/main/java/sample/test/dto/NotificationRequestDto.java
@@ -1,0 +1,13 @@
+package sample.test.dto;
+
+public class NotificationRequestDto {
+    private String title;
+    private String body;
+    private String image;
+
+    public NotificationRequestDto(String title, String body, String image) {
+        this.title = title;
+        this.body = body;
+        this.image = image;
+    }
+}

--- a/gui/Test/src/main/java/sample/test/utils/NotificationUtils.java
+++ b/gui/Test/src/main/java/sample/test/utils/NotificationUtils.java
@@ -1,0 +1,48 @@
+package sample.test.utils;
+
+import com.google.gson.Gson;
+import sample.test.dto.NotificationRequestDto;
+import sample.test.service.JwtTokenService;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+
+public class NotificationUtils {
+    private final static String METHOD = "POST";
+    private final static String FCM_URL = "http://localhost:8080/api/notifications/send/to/topic/";
+
+    public static String sendNotification(
+            String topic,
+            NotificationRequestDto notificationRequestDto
+    ) throws Exception {
+
+            getRequirements result = getGetRequirements(topic, notificationRequestDto);
+            HttpResponse<String> response = HttpUtils.sendHttpRequest(result.url(), METHOD, result.token(), result.jsonInputString());
+            return checkResponse(response);
+
+
+    }
+
+    private static getRequirements getGetRequirements(String topic, NotificationRequestDto notificationRequestDto) {
+        String url = FCM_URL + topic;
+        String token = JwtTokenService.getInstance().getJwtToken();
+        String jsonInputString = new Gson().toJson(notificationRequestDto);
+        getRequirements result = new getRequirements(url, token, jsonInputString);
+        return result;
+    }
+
+    private record getRequirements(String url, String token, String jsonInputString) {
+    }
+
+    private static String checkResponse(HttpResponse<String> response) throws IOException {
+        if (HttpUtils.checkIfResponseWasGood(response)) {
+            return response.body();
+        }
+        else if (HttpUtils.checkIfResponseWasUnauthorized(response)) {
+            throw new IOException("Unauthorized");
+        }
+        else {
+            throw new IOException("Failed to send notification");
+        }
+    }
+}

--- a/gui/Test/src/main/resources/sample/test/employee-view.fxml
+++ b/gui/Test/src/main/resources/sample/test/employee-view.fxml
@@ -68,6 +68,11 @@
                      <font>
                         <Font name="Arial" size="13.0" />
                      </font></Button>
+                        <Button fx:id="sendNotificationPaneButton" layoutY="463.0" mnemonicParsing="false" onAction="#sendNotif" prefHeight="40.0" prefWidth="200.0" styleClass="nav-button" text="Send Notif">
+                            <font>
+                                <Font name="Arial" size="13.0" />
+                            </font></Button>
+
                   <ImageView fitHeight="150.0" fitWidth="200.0" layoutX="25.0" layoutY="14.0" pickOnBounds="true" preserveRatio="true">
                      <image>
                         <Image url="@images/logo.png" />
@@ -80,6 +85,58 @@
                     <children>
                         <AnchorPane layoutX="238.0" layoutY="233.0" prefHeight="637.0" prefWidth="859.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                             <children>
+                                <AnchorPane fx:id="notificationPane" prefHeight="637.0" prefWidth="859.0" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                    <children>
+                                        <AnchorPane layoutX="30.0" layoutY="31.0" prefHeight="400.0" prefWidth="500.0" styleClass="bg-white">
+                                            <children>
+                                                <Label layoutX="30.0" layoutY="30.0" text="Notification Title:">
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </Label>
+                                                <TextField fx:id="notificationTitleField" layoutX="30.0" layoutY="60.0" prefHeight="40.0" prefWidth="440.0" >
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </TextField>
+
+                                                <Label layoutX="30.0" layoutY="120.0" text="Notification Body:">
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </Label>
+                                                <TextField fx:id="notificationBodyField" layoutX="30.0" layoutY="150.0" prefHeight="100.0" prefWidth="440.0" >
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </TextField>
+
+                                                <Label layoutX="30.0" layoutY="270.0" text="Image URL:">
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </Label>
+                                                <TextField fx:id="notificationImageField" layoutX="30.0" layoutY="300.0" prefHeight="40.0" prefWidth="440.0" >
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </TextField>
+
+                                                <Button fx:id="sendNotificationButton" layoutX="30.0" layoutY="348.0" mnemonicParsing="false" onAction="#handleSendNotification" prefHeight="40.0" prefWidth="200.0" styleClass="form-button" text="Send Notification">
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </Button>
+
+                                                <Label fx:id="notificationResponseLabel" layoutX="30.0" layoutY="420.0" prefHeight="40.0" prefWidth="440.0" wrapText="true" styleClass="response-label">
+                                                    <font>
+                                                        <Font name="Arial" size="14.0" />
+                                                    </font>
+                                                </Label>
+                                            </children>
+                                        </AnchorPane>
+                                    </children>
+                                </AnchorPane>
                                 <AnchorPane fx:id="staffPane" prefHeight="637.0" prefWidth="859.0" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <children>
                                         <AnchorPane fx:id="employeePane" layoutX="30.0" layoutY="31.0" prefHeight="162.0" prefWidth="369.0" styleClass="bg-white">


### PR DESCRIPTION
# Feature: Sending Notifications from GUI

## Overview
This pull request implements the functionality to send Firebase Cloud Messaging (FCM) notifications from the backend, triggered via a JavaFX GUI. The main components of this feature include:

- **Backend Enhancements**: 
  - Added a new controller to handle incoming requests for sending notifications.
  - Developed a service to integrate with Firebase Messaging for notification delivery.

- **JavaFX Integration**: 
  - Implemented a JavaFX Pane that allows users to input notification details and trigger the sending process.
  
## Changes Made
- **Controller**:
  - Created `NotificationController` to manage API endpoints for sending notifications.
  - Endpoint to receive notification requests from the GUI.

- **Service**:
  - Developed `NotificationService` to encapsulate the logic for sending notifications through Firebase.
  - Utilized Firebase Admin SDK to interact with the FCM service.

- **JavaFX UI**:
  - Fixed Orders Board refreshing
  - Added a user-friendly interface in the JavaFX application, allowing users to enter the notification title, message, and target recipients.
  - Implemented functionality to capture user inputs and send them to the backend.


## Notes
- Ensure that Firebase credentials are properly set up in the backend for notification delivery.
- Update any related documentation to reflect the new functionality.

## Screenshots
![image](https://github.com/user-attachments/assets/bde415a8-690f-4581-8260-b4bb023a05eb)


